### PR TITLE
NormalButton の追加

### DIFF
--- a/src/components/form/inputs/Button.tsx
+++ b/src/components/form/inputs/Button.tsx
@@ -1,3 +1,0 @@
-export const Button = () => {
-  return <div>Button</div>;
-};

--- a/src/components/form/inputs/NormalButton/NormalButton.component.tsx
+++ b/src/components/form/inputs/NormalButton/NormalButton.component.tsx
@@ -1,0 +1,16 @@
+import { default as MuiButton } from '@mui/material/Button';
+import { ButtonProps } from './NormalButton.type';
+
+export const NormalButton = ({
+  label,
+  variant = 'contained',
+  disabled,
+  color = 'error',
+  ...rest
+}: ButtonProps) => {
+  return (
+    <MuiButton variant={variant} disabled={disabled} color={color} {...rest}>
+      {label}
+    </MuiButton>
+  );
+};

--- a/src/components/form/inputs/NormalButton/NormalButton.component.tsx
+++ b/src/components/form/inputs/NormalButton/NormalButton.component.tsx
@@ -3,13 +3,20 @@ import { ButtonProps } from './NormalButton.type';
 
 export const NormalButton = ({
   label,
+  onClick,
   variant = 'contained',
   disabled,
   color = 'error',
   ...rest
 }: ButtonProps) => {
   return (
-    <MuiButton variant={variant} disabled={disabled} color={color} {...rest}>
+    <MuiButton
+      variant={variant}
+      disabled={disabled}
+      color={color}
+      onClick={onClick}
+      {...rest}
+    >
       {label}
     </MuiButton>
   );

--- a/src/components/form/inputs/NormalButton/NormalButton.stories.tsx
+++ b/src/components/form/inputs/NormalButton/NormalButton.stories.tsx
@@ -13,5 +13,5 @@ const Template: StoryFn<typeof NormalButton> = args => (
 
 export const Contained = Template.bind({});
 Contained.args = {
-  label: 'Normal'
+  label: 'Normal',
 };

--- a/src/components/form/inputs/NormalButton/NormalButton.stories.tsx
+++ b/src/components/form/inputs/NormalButton/NormalButton.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentMeta, StoryFn } from '@/utils/storybook';
+import { NormalButton } from './NormalButton.component';
+
+const NormalButtonStory: ComponentMeta<typeof NormalButton> = {
+  component: NormalButton,
+};
+
+export default NormalButtonStory;
+
+const Template: StoryFn<typeof NormalButton> = args => (
+  <NormalButton {...args} />
+);
+
+export const Contained = Template.bind({});
+Contained.args = {
+  label: 'Normal'
+};

--- a/src/components/form/inputs/NormalButton/NormalButton.stories.tsx
+++ b/src/components/form/inputs/NormalButton/NormalButton.stories.tsx
@@ -15,3 +15,15 @@ export const Contained = Template.bind({});
 Contained.args = {
   label: 'Normal',
 };
+
+export const Outlined = Template.bind({});
+Outlined.args = {
+  label: 'Normal',
+  variant: 'outlined',
+};
+
+export const Text = Template.bind({});
+Text.args = {
+  label: 'Normal',
+  variant: 'text',
+};

--- a/src/components/form/inputs/NormalButton/NormalButton.stories.tsx
+++ b/src/components/form/inputs/NormalButton/NormalButton.stories.tsx
@@ -14,16 +14,19 @@ const Template: StoryFn<typeof NormalButton> = args => (
 export const Contained = Template.bind({});
 Contained.args = {
   label: 'Normal',
+  disabled: false,
 };
 
 export const Outlined = Template.bind({});
 Outlined.args = {
   label: 'Normal',
   variant: 'outlined',
+  disabled: false,
 };
 
 export const Text = Template.bind({});
 Text.args = {
   label: 'Normal',
   variant: 'text',
+  disabled: false,
 };

--- a/src/components/form/inputs/NormalButton/NormalButton.type.ts
+++ b/src/components/form/inputs/NormalButton/NormalButton.type.ts
@@ -1,0 +1,5 @@
+import { ButtonProps as MuiButtonProps } from '@mui/material/Button';
+
+export type ButtonProps = MuiButtonProps & {
+  label: string;
+};

--- a/src/components/form/inputs/NormalButton/NormalButton.type.ts
+++ b/src/components/form/inputs/NormalButton/NormalButton.type.ts
@@ -2,4 +2,5 @@ import { ButtonProps as MuiButtonProps } from '@mui/material/Button';
 
 export type ButtonProps = MuiButtonProps & {
   label: string;
+  onClick: React.MouseEventHandler<HTMLButtonElement> | undefined;
 };


### PR DESCRIPTION
# やったこと
主にサインアップ画面で用いられる、決定や確認などの「アイコンを持たないボタン」の作成。

# やらないこと
具体的な width/ height の指定がまだないので `sx` は空欄

# レビュー前チェックシート(全てチェックしてからレビュー依頼)

- [x] セルフレビューをした
- [x] 手元でテストが通った
  - [x] `yarn lint`
  - [x] `yarn test`
  - [x] `yarn build`
