### PR TITLE
Footer Component

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,3 +1,0 @@
-export const Footer = () => {
-  return <div>Footer</div>;
-};

--- a/src/components/Footer/Footer.component.tsx
+++ b/src/components/Footer/Footer.component.tsx
@@ -10,7 +10,12 @@ import {
 export const Footer = () => {
   return (
     <StackChildren flexDirection="row">
-      <IconWithLabel icon={LocationOn} label={'マップ'} fullWidth color='error' />
+      <IconWithLabel
+        icon={LocationOn}
+        label={'マップ'}
+        fullWidth
+        color="error"
+      />
       <IconWithLabel icon={ManageSearch} label={'探す'} fullWidth />
       <IconWithLabel icon={CropFree} label={'QRリーダー'} fullWidth />
       <IconWithLabel icon={Approval} label={'スタンプ'} fullWidth />

--- a/src/components/Footer/Footer.component.tsx
+++ b/src/components/Footer/Footer.component.tsx
@@ -1,0 +1,19 @@
+import { IconWithLabel } from '../commons/IconWithLabel/IconWithLabel.component';
+import { StackChildren } from '../commons/Styling/StackChildren/StackChildren';
+import {
+  Approval,
+  LocationOn,
+  ManageSearch,
+  CropFree,
+} from '@mui/icons-material';
+
+export const Footer = () => {
+  return (
+    <StackChildren flexDirection="row">
+      <IconWithLabel icon={LocationOn} label={'マップ'} fullWidth />
+      <IconWithLabel icon={ManageSearch} label={'探す'} fullWidth />
+      <IconWithLabel icon={CropFree} label={'QRリーダー'} fullWidth />
+      <IconWithLabel icon={Approval} label={'スタンプ'} fullWidth />
+    </StackChildren>
+  );
+};

--- a/src/components/Footer/Footer.component.tsx
+++ b/src/components/Footer/Footer.component.tsx
@@ -10,7 +10,7 @@ import {
 export const Footer = () => {
   return (
     <StackChildren flexDirection="row">
-      <IconWithLabel icon={LocationOn} label={'マップ'} fullWidth />
+      <IconWithLabel icon={LocationOn} label={'マップ'} fullWidth color='error' />
       <IconWithLabel icon={ManageSearch} label={'探す'} fullWidth />
       <IconWithLabel icon={CropFree} label={'QRリーダー'} fullWidth />
       <IconWithLabel icon={Approval} label={'スタンプ'} fullWidth />

--- a/src/components/Footer/Footer.stories.tsx
+++ b/src/components/Footer/Footer.stories.tsx
@@ -1,0 +1,12 @@
+import { ComponentMeta } from '@/utils/storybook';
+import { Footer } from './Footer.component';
+
+const FooterStory: ComponentMeta<typeof Footer> = {
+  component: Footer,
+};
+
+export default FooterStory;
+
+export const FooterDemo = () => {
+  return <Footer />;
+};

--- a/src/components/commons/IconWithLabel/IconWithLabel.component.tsx
+++ b/src/components/commons/IconWithLabel/IconWithLabel.component.tsx
@@ -21,7 +21,3 @@ export const IconWithLabel = ({
     </MuiButton>
   );
 };
-
-// TODO
-// Footer に並べるときに等幅にする
-// issues #42

--- a/src/components/commons/IconWithLabel/IconWithLabel.component.tsx
+++ b/src/components/commons/IconWithLabel/IconWithLabel.component.tsx
@@ -5,7 +5,7 @@ import { Button as MuiButton, Typography } from '@mui/material';
 export const IconWithLabel = ({
   label,
   icon,
-  variant = 'contained',
+  variant = 'text',
   disabled,
   color = 'inherit',
   ...rest

--- a/src/components/commons/IconWithLabel/IconWithLabel.component.tsx
+++ b/src/components/commons/IconWithLabel/IconWithLabel.component.tsx
@@ -7,7 +7,7 @@ export const IconWithLabel = ({
   icon,
   variant = 'contained',
   disabled,
-  color = 'error',
+  color = 'inherit',
   ...rest
 }: IconWithLabelProps) => {
   const IconComponent = icon;


### PR DESCRIPTION
# やったこと
Footerコンポーネントの作成
各ボタンは等幅で配置、親の `StackChildren` に `gap` を持たせれば余白取れます。
子の `IconWithLabel` に `color` を持たせれば色変えられます。

# やらないこと
現在のページを判断してボタンの色変える

# レビュー前チェックシート(全てチェックしてからレビュー依頼)

- [x] セルフレビューをした
- [ ] 手元でテストが通った
  - [x] `yarn lint`
  - [ ] `yarn test`
  - [x] `yarn build`
