### PR TITLE
郵便番号と住所をアイコン付きに整形するコンポネント

### DIFF
--- a/src/components/commons/Styling/PostCode/PostCode.component.tsx
+++ b/src/components/commons/Styling/PostCode/PostCode.component.tsx
@@ -7,11 +7,12 @@ import { StackChildren } from '../StackChildren/StackChildren';
 
 export const PostCode = ({ postCode, address }: PostCodeProps) => {
   // 郵便番号の整形
-  const postCodeString = postCode.toString();
-  const firstPart = postCodeString.slice(0, 3);
-  const secondPart = postCodeString.slice(3, 7);
-
-  const fixedPostCode = `${firstPart}-${secondPart}`;
+  const fixedPostCode = useMemo(() => {
+    const postCodeString = postCode.toString();
+    const firstPart = postCodeString.slice(0, 3);
+    const secondPart = postCodeString.slice(3, 7);
+    return `${firstPart}-${secondPart}`;
+  }, [postCode]);
 
   return (
     <div style={{ display: 'flex', maxWidth: '100px' }}>

--- a/src/components/commons/Styling/PostCode/PostCode.component.tsx
+++ b/src/components/commons/Styling/PostCode/PostCode.component.tsx
@@ -1,29 +1,30 @@
 import { LocationOn } from '@mui/icons-material';
-import { ThemeProvider, createTheme } from '@mui/material/styles';
 import { useMemo } from 'react';
 
 import { Stack } from '@/features/ui/Stack';
 import { Typography } from '@/features/ui/Typography';
+import { SxProps, Theme } from '@/features/ui/library';
 
 import { PostCodeProps } from './PostCode.type';
 
-export const PostCode = ({ postCode, address }: PostCodeProps) => {
-  const iconSize = 20;
-  const fieldWidth = 146;
-  const fontSize = 12;
+const iconSize = 20;
+const fieldWidth = 146;
+const fontSize = 12;
 
-  // アイコンのサイズ変更
-  const theme = createTheme({
-    components: {
-      MuiSvgIcon: {
-        styleOverrides: {
-          root: {
-            fontSize: iconSize,
-          },
-        },
-      },
+export const PostCode = ({ postCode, address }: PostCodeProps) => {
+
+  const IconSxProps = {
+    '&.MuiSvgIcon-root': {
+      fontSize: iconSize,
     },
-  });
+  } satisfies SxProps<Theme>;
+
+  const FontSx = {
+    '&.MuiTypography-root': {
+      fontSize,
+      lineHeight: 'normal',
+    },
+  };
 
   // 郵便番号の整形
   const fixedPostCode = useMemo(() => {
@@ -34,18 +35,16 @@ export const PostCode = ({ postCode, address }: PostCodeProps) => {
   }, [postCode]);
 
   return (
-    <ThemeProvider theme={theme}>
-      <Stack
-        spacing={0}
-        flexDirection="row"
-        sx={{ maxWidth: iconSize + fieldWidth }}
-      >
-        <LocationOn sx={{ marginRight: 0 }} />
-        <Typography isTruncated sx={{ fontSize, lineHeight: 'normal' }}>
-          〒{fixedPostCode}
-          {address}
-        </Typography>
-      </Stack>
-    </ThemeProvider>
+    <Stack
+      spacing={0}
+      flexDirection="row"
+      sx={{ maxWidth: iconSize + fieldWidth }}
+    >
+      <LocationOn sx={IconSxProps} />
+      <Typography isTruncated sx={FontSx}>
+        〒{fixedPostCode}
+        {address}
+      </Typography>
+    </Stack>
   );
 };

--- a/src/components/commons/Styling/PostCode/PostCode.component.tsx
+++ b/src/components/commons/Styling/PostCode/PostCode.component.tsx
@@ -12,7 +12,6 @@ const fieldWidth = 146;
 const fontSize = 12;
 
 export const PostCode = ({ postCode, address }: PostCodeProps) => {
-
   const IconSxProps = {
     '&.MuiSvgIcon-root': {
       fontSize: iconSize,

--- a/src/components/commons/Styling/PostCode/PostCode.component.tsx
+++ b/src/components/commons/Styling/PostCode/PostCode.component.tsx
@@ -41,7 +41,7 @@ export const PostCode = ({ postCode, address }: PostCodeProps) => {
         sx={{ maxWidth: iconSize + fieldWidth }}
       >
         <LocationOn sx={{ marginRight: 0 }} />
-        <Typography isTruncated sx={{ fontSize, lineHeight: 'inherit' }}>
+        <Typography isTruncated sx={{ fontSize, lineHeight: 'normal' }}>
           〒{fixedPostCode}
           {address}
         </Typography>

--- a/src/components/commons/Styling/PostCode/PostCode.component.tsx
+++ b/src/components/commons/Styling/PostCode/PostCode.component.tsx
@@ -23,7 +23,7 @@ export const PostCode = ({ postCode, address }: PostCodeProps) => {
       fontSize,
       lineHeight: 'normal',
     },
-  };
+  } satisfies SxProps<Theme>;
 
   // 郵便番号の整形
   const fixedPostCode = useMemo(() => {

--- a/src/components/commons/Styling/PostCode/PostCode.component.tsx
+++ b/src/components/commons/Styling/PostCode/PostCode.component.tsx
@@ -1,11 +1,30 @@
 import { LocationOn } from '@mui/icons-material';
+import { ThemeProvider, createTheme } from '@mui/material/styles';
+import { useMemo } from 'react';
 
+import { Stack } from '@/features/ui/Stack';
 import { Typography } from '@/features/ui/Typography';
 
 import { PostCodeProps } from './PostCode.type';
-import { Stack } from '@/features/ui/Stack';
 
 export const PostCode = ({ postCode, address }: PostCodeProps) => {
+  const iconSize = 20;
+  const fieldWidth = 146;
+  const fontSize = 12;
+
+  // アイコンのサイズ変更
+  const theme = createTheme({
+    components: {
+      MuiSvgIcon: {
+        styleOverrides: {
+          root: {
+            fontSize: iconSize,
+          },
+        },
+      },
+    },
+  });
+
   // 郵便番号の整形
   const fixedPostCode = useMemo(() => {
     const postCodeString = postCode.toString();
@@ -15,11 +34,18 @@ export const PostCode = ({ postCode, address }: PostCodeProps) => {
   }, [postCode]);
 
   return (
-    <Stack flexDirection="row" sx={{ maxWidth: '100px' }}>
-      <LocationOn sx={{ marginRight: '5px' }} />
-      <Typography isTruncated>
-        〒 {fixedPostCode} {address}
-      </Typography>
-    </Stack>
+    <ThemeProvider theme={theme}>
+      <Stack
+        spacing={0}
+        flexDirection="row"
+        sx={{ maxWidth: iconSize + fieldWidth }}
+      >
+        <LocationOn sx={{ marginRight: 0 }} />
+        <Typography isTruncated sx={{ fontSize, lineHeight: 'inherit' }}>
+          〒{fixedPostCode}
+          {address}
+        </Typography>
+      </Stack>
+    </ThemeProvider>
   );
 };

--- a/src/components/commons/Styling/PostCode/PostCode.component.tsx
+++ b/src/components/commons/Styling/PostCode/PostCode.component.tsx
@@ -1,0 +1,26 @@
+import { LocationOn } from '@mui/icons-material';
+
+import { Typography } from '@/features/ui/Typography';
+
+import { PostCodeProps } from './PostCode.type';
+import { StackChildren } from '../StackChildren/StackChildren';
+
+export const PostCode = ({ postCode, address }: PostCodeProps) => {
+  // 郵便番号の整形
+  const postCodeString = postCode.toString();
+  const firstPart = postCodeString.slice(0, 3);
+  const secondPart = postCodeString.slice(3, 7);
+
+  const fixedPostCode = `${firstPart}-${secondPart}`;
+
+  return (
+    <div style={{ display: 'flex', maxWidth: '100px' }}>
+      <StackChildren flexDirection="row">
+        <LocationOn sx={{ marginRight: '5px' }} />
+        <Typography isTruncated>
+          〒 {fixedPostCode} {address}
+        </Typography>
+      </StackChildren>
+    </div>
+  );
+};

--- a/src/components/commons/Styling/PostCode/PostCode.component.tsx
+++ b/src/components/commons/Styling/PostCode/PostCode.component.tsx
@@ -15,13 +15,11 @@ export const PostCode = ({ postCode, address }: PostCodeProps) => {
   }, [postCode]);
 
   return (
-    <div style={{ display: 'flex', maxWidth: '100px' }}>
-      <StackChildren flexDirection="row">
-        <LocationOn sx={{ marginRight: '5px' }} />
-        <Typography isTruncated>
-          〒 {fixedPostCode} {address}
-        </Typography>
-      </StackChildren>
-    </div>
+    <Stack flexDirection="row" sx={{ maxWidth: '100px' }}>
+      <LocationOn sx={{ marginRight: '5px' }} />
+      <Typography isTruncated>
+        〒 {fixedPostCode} {address}
+      </Typography>
+    </Stack>
   );
 };

--- a/src/components/commons/Styling/PostCode/PostCode.component.tsx
+++ b/src/components/commons/Styling/PostCode/PostCode.component.tsx
@@ -3,7 +3,7 @@ import { LocationOn } from '@mui/icons-material';
 import { Typography } from '@/features/ui/Typography';
 
 import { PostCodeProps } from './PostCode.type';
-import { StackChildren } from '../StackChildren/StackChildren';
+import { Stack } from '@/features/ui/Stack';
 
 export const PostCode = ({ postCode, address }: PostCodeProps) => {
   // 郵便番号の整形

--- a/src/components/commons/Styling/PostCode/PostCode.stories.tsx
+++ b/src/components/commons/Styling/PostCode/PostCode.stories.tsx
@@ -1,0 +1,19 @@
+import { ComponentMeta, StoryFn } from '@/utils/storybook';
+
+import { PostCode } from './PostCode.component';
+
+const PostCodeStory: ComponentMeta<typeof PostCode> = {
+  component: PostCode,
+};
+
+export default PostCodeStory;
+
+const Template: StoryFn<typeof PostCode> = args => {
+  return <PostCode {...args} />;
+};
+
+export const PostCodeDemo = Template.bind({});
+PostCodeDemo.args = {
+  postCode: 9430831,
+  address: '新潟県上越市',
+};

--- a/src/components/commons/Styling/PostCode/PostCode.type.ts
+++ b/src/components/commons/Styling/PostCode/PostCode.type.ts
@@ -1,0 +1,4 @@
+export type PostCodeProps = {
+  postCode: number;
+  address: string;
+};


### PR DESCRIPTION
# やったこと
7桁の郵便番号と住所をアイコン付きに整形

# やらないこと
`isTruncated` がうまく動かなかった (そもそもここじゃない？)

# レビュー前チェックシート(全てチェックしてからレビュー依頼)

- [x] セルフレビューをした
- [x] 手元でテストが通った
  - [x] `yarn lint`
  - [x] `yarn test`
  - [x] `yarn build`
